### PR TITLE
feat(nav): highlight active tab

### DIFF
--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
 
 const tabs: { href: '/' | '/transactions' | '/categories'; label: string }[] = [
   { href: "/", label: "Dashboard" },
@@ -13,14 +14,19 @@ export default function Nav() {
   return (
     <nav className="container" style={{marginTop:"1rem"}}>
       <div className="card" style={{display:"flex", gap:".5rem"}}>
-        {tabs.map(t => (
-          <Link key={t.href} href={t.href}
-            className={`btn secondary ${pathname === t.href ? "" : ""}`}
-            style={{textDecoration: pathname===t.href ? "underline" : "none"}}
-          >
-            {t.label}
-          </Link>
-        ))}
+        {tabs.map((t) => {
+          const isActive = pathname === t.href;
+          return (
+            <Link
+              key={t.href}
+              href={t.href}
+              className={cn("btn", isActive ? "underline" : "secondary")}
+              aria-current={isActive ? "page" : undefined}
+            >
+              {t.label}
+            </Link>
+          );
+        })}
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary
- highlight active navigation tab when matching current path

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68959bfaa34483319836c301888191cf