### PR TITLE
Improve category creation feedback and type safety

### DIFF
--- a/components/AddCategoryForm.tsx
+++ b/components/AddCategoryForm.tsx
@@ -3,6 +3,8 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { supabase } from "@/lib/supabaseClient";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 const schema = z.object({
   name: z.string().min(1, "Required"),
@@ -10,19 +12,25 @@ const schema = z.object({
 });
 
 export default function AddCategoryForm() {
+  const router = useRouter();
+  const [message, setMessage] = useState<{ type: "error" | "success"; text: string } | null>(null);
   const { register, handleSubmit, reset, formState:{errors, isSubmitting} } = useForm({
     resolver: zodResolver(schema),
     defaultValues: { type: "expense" }
   });
 
-  const onSubmit = async (values: any) => {
+  const onSubmit = async (values: z.infer<typeof schema>) => {
     const { data: user } = await supabase.auth.getUser();
-    if (!user.user) { alert("Please log in first."); return; }
+    if (!user.user) { setMessage({ type: "error", text: "Please log in first." }); return; }
     const { error } = await supabase.from("categories").insert({
       user_id: user.user.id, name: values.name, type: values.type
     });
-    if (error) alert(error.message);
-    else { reset({ name:"", type:"expense" }); location.reload(); }
+    if (error) setMessage({ type: "error", text: error.message });
+    else {
+      reset({ name:"", type:"expense" });
+      setMessage({ type: "success", text: "Category added." });
+      router.refresh();
+    }
   };
 
   return (
@@ -39,6 +47,11 @@ export default function AddCategoryForm() {
           <option value="income">Income</option>
         </select>
       </div>
+      {message && (
+        <div style={{color: message.type === "error" ? "#f87171" : "#4ade80"}}>
+          {message.text}
+        </div>
+      )}
       <button className="btn" disabled={isSubmitting}>Add Category</button>
     </form>
   );


### PR DESCRIPTION
## Summary
- type AddCategoryForm submission with `z.infer` for better safety
- show inline success/error message instead of alerts
- refresh router to update categories without page reload

## Testing
- `pnpm lint` *(fails: next lint requests interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68959d19dbe48331952d40e898db3171